### PR TITLE
readme: add how to update a package guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,23 @@ Not required currently:
 python3-pytest-httpserver
 └── python3-typing
 ```
+
+# How to update a package
+
+E.g. when `python-asyncopenctackclient` was updated to `0.9.0`. In the
+package repository:
+
+1. Bump version and add changelog entry:
+   `vim AsyncOpenStackClient.spec`
+
+2. Download new sources (tarball):
+   `spectool -g -R AsyncOpenStackClient.spec`
+
+3. Create srpm:
+   `fedpkg srpm`
+
+4. Check files in srpm (optional):
+   `rpmls python-AsyncOpenStackClient-0.9.0-1.fc40.src.rpm`
+
+5. Create a new build via COPR CLI (requires token in `~/.config/copr`, see https://copr.fedorainfracloud.org/api/):
+   `copr build @freeipa/neoave ./python-AsyncOpenStackClient-0.9.0-1.fc40.src.rpm`


### PR DESCRIPTION
To "remember" the next time somebody needs to update it.